### PR TITLE
Update GetMenu.lua

### DIFF
--- a/src/ReplicatedStorage/DominoPizzaAPI/GetMenu.lua
+++ b/src/ReplicatedStorage/DominoPizzaAPI/GetMenu.lua
@@ -1,13 +1,10 @@
 local HttpService = game:GetService("HttpService")
-local URL = require(game.ReplicatedStorage.DominoPizzaAPI.URL)
+local DominoPizzaAPI = require(game.ReplicatedStorage.DominoPizzaAPI.URL)
 local GetMenu = {}
--- TODO: Use luau variable stricting
+
 function GetMenu.GetStoreMenu(StoreID)
     assert(StoreID,'Missing argument : the Store ID must be provided')
-    if type(StoreID) == 'number' then
-        tostring(StoreID)
-    end
-    local data = HttpService:JSONDecode(HttpService:GetAsync(URL.URL.Canada.Menu .. StoreID .. '/menu?lang=en&structured=true'))
+    local data = HttpService:JSONDecode(HttpService:GetAsync(DominoPizzaAPI.URL.Canada.Menu .. StoreID .. '/menu?lang=en&structured=true'))
     return data
 end
 


### PR DESCRIPTION
- Removed number -> string conversion since numbers are already concatenated as strings. 
    - tostring(number) returns a string, it does not directly change the variable to one. 

- Renamed URL to DominoPizzaAPI to make request cleaner.

Note: I don’t think typed Lua will work in external text editors, editor integration hasn’t been implemented yet.